### PR TITLE
feat: download-all button for Exambase PDFs

### DIFF
--- a/content_exambase.js
+++ b/content_exambase.js
@@ -92,13 +92,27 @@
       // Debug logs (visible in page console)
       console.log("[ExambaseRenamer] courseCode:", courseCode);
       console.log("[ExambaseRenamer] resources:", resources);
-  
+
       // Send to background
       chrome.runtime.sendMessage({
         type: "PAGE_INFO_EXAMBASE",
         courseCode,
         resources
       }, () => void 0);
+
+      // Listen for "download all" requests from the popup
+      chrome.runtime.onMessage.addListener((msg) => {
+        if (msg?.type === 'DOWNLOAD_ALL_PDF_EXAMBASE') {
+          Object.entries(resources).forEach(([pdfUrl, info]) => {
+            chrome.runtime.sendMessage({
+              type: 'DOWNLOAD_PDF_EXAMBASE',
+              pdfUrl,
+              courseCode: info.courseCode,
+              examDate: info.examDate
+            });
+          });
+        }
+      });
     } catch (e) {
       console.error("[ExambaseRenamer] content script error:", e);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     },
     "permissions": [
       "downloads",
-      "storage"
+      "storage",
+      "tabs"
     ],
     "host_permissions": [
       "https://exambase-lib-hku-hk.eproxy.lib.hku.hk/*"
@@ -18,6 +19,9 @@
     "background": {
       "service_worker": "background.js",
       "type": "module"
+    },
+    "action": {
+      "default_popup": "popup.html"
     },
     "content_scripts": [
       {

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Exambase Renamer</title>
+  <style>
+    body { font-family: sans-serif; margin: 10px; }
+    button { padding: 6px 12px; }
+  </style>
+</head>
+<body>
+  <button id="download-all">Download All PDFs</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,11 @@
+// Trigger downloads for all past paper PDFs on the current page
+const btn = document.getElementById('download-all');
+btn.addEventListener('click', () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    const tabId = tabs[0]?.id;
+    if (tabId != null) {
+      chrome.tabs.sendMessage(tabId, { type: 'DOWNLOAD_ALL_PDF_EXAMBASE' });
+    }
+    window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add popup with button to download all past paper PDFs on a page
- support popup action via manifest and tabs permission
- wire content script to handle download-all messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9aa15dc0832ea335de7a615c33a3